### PR TITLE
set pytest config in pyprotect.toml to avoid verbose decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ load-plugins = "pylint_google_style_guide_imports_enforcing"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/adapters/allowlist/test_adapter.py
+++ b/tests/adapters/allowlist/test_adapter.py
@@ -14,7 +14,6 @@ def invalid_address() -> str:
 
 
 def describe_allowlist_adapter() -> None:
-    @pytest.mark.asyncio
     async def it_works_e2e(valid_address: str, invalid_address: str) -> None:
         result = await adapter.AllowListAdapter.fetch(valid_address, "goerli")
         assert result == adapter.AllowListSignal(on_allowlist=True)

--- a/tests/adapters/lending_pools/test_adapter.py
+++ b/tests/adapters/lending_pools/test_adapter.py
@@ -1,7 +1,5 @@
 import decimal
 
-import pytest
-
 from huma_signals.adapters.lending_pools import adapter
 
 
@@ -12,7 +10,6 @@ def describe_adapter() -> None:
     def it_returns_the_required_inputs() -> None:
         assert adapter.LendingPoolAdapter.required_inputs == ["pool_address"]
 
-    @pytest.mark.asyncio
     async def it_fetches_the_signals_from_creditline_pool() -> None:
         pool_address = "0xA22D20FB0c9980fb96A9B0B5679C061aeAf5dDE4"
         signals = await adapter.LendingPoolAdapter.fetch(pool_address)
@@ -27,7 +24,6 @@ def describe_adapter() -> None:
         assert signals.invoice_amount_ratio == 0.8
         assert signals.is_testnet is True
 
-    @pytest.mark.asyncio
     async def it_fetches_the_signals_from_invoice_factoring_pool() -> None:
         pool_address = "0x11672c0bBFF498c72BC2200f42461c0414855042"
         signals = await adapter.LendingPoolAdapter.fetch(pool_address)

--- a/tests/adapters/request_network/test_adapter.py
+++ b/tests/adapters/request_network/test_adapter.py
@@ -23,7 +23,6 @@ def describe_adapter() -> None:
                 "0x63d6287d5b853ccfedba1247fbeb9a40512f709a".lower()
             )  # gitleaks:allow
 
-        @pytest.mark.asyncio
         async def it_returns_payer_payment_history(
             rn_subgraph_endpoint_url: str, from_address: str
         ) -> None:
@@ -34,7 +33,6 @@ def describe_adapter() -> None:
             assert payments[-1]["from"] == from_address
             assert payments[-1]["to"].startswith("0x")
 
-        @pytest.mark.asyncio
         async def it_returns_payee_payment_history(
             rn_subgraph_endpoint_url: str, to_address: str
         ) -> None:
@@ -81,7 +79,6 @@ def describe_adapter() -> None:
         def payee_wallet_address() -> str:
             return "0x41D33Eb68af3efa12d69B68FFCaF1887F9eCfEC0".lower()
 
-        @pytest.mark.asyncio
         async def it_can_fetch_signals(
             rn_subgraph_endpoint_url: str,
             rn_invoice_api_url: str,

--- a/tests/adapters/request_network/test_models.py
+++ b/tests/adapters/request_network/test_models.py
@@ -28,7 +28,6 @@ def rn_invoice_api_url() -> str:
 
 
 def describe_invoice() -> None:
-    @pytest.mark.asyncio
     async def it_can_be_initialized_with_a_receivable_param(
         receivable_param: str,
         rn_invoice_api_url: str,

--- a/tests/adapters/test_registry.py
+++ b/tests/adapters/test_registry.py
@@ -136,7 +136,6 @@ def describe_adapter_registry() -> None:
 
 
 def describe_fetch_signal() -> None:
-    @pytest.mark.asyncio
     async def it_returns_the_correct_signal(
         dummy_registry: Dict[str, Type[adapter_models.SignalAdapterBase]]
     ) -> None:
@@ -145,7 +144,6 @@ def describe_fetch_signal() -> None:
         )
         assert signals == {"dummy_adapter.test_signal": 10}
 
-    @pytest.mark.asyncio
     async def it_returns_the_correct_signals_with_type_conversion(
         dummy_registry: Dict[str, Type[adapter_models.SignalAdapterBase]]
     ) -> None:
@@ -154,7 +152,6 @@ def describe_fetch_signal() -> None:
         )
         assert signals == {"dummy_adapter.test_signal2": "20"}
 
-    @pytest.mark.asyncio
     async def it_returns_the_correct_signals_with_multiple_adapters(
         dummy_registry: Dict[str, Type[adapter_models.SignalAdapterBase]]
     ) -> None:

--- a/tests/adapters/wallet_eth_txns/test_adapter.py
+++ b/tests/adapters/wallet_eth_txns/test_adapter.py
@@ -10,7 +10,6 @@ def valid_address() -> str:
 
 
 def describe_wallet_eth_txns_adapter() -> None:
-    @pytest.mark.asyncio
     async def it_works_e2e(valid_address: str) -> None:
         result = await adapter.EthereumWalletAdapter.fetch(valid_address)
         assert result is not None

--- a/tests/commons/test_chains.py
+++ b/tests/commons/test_chains.py
@@ -42,7 +42,6 @@ def describe_chain() -> None:
 
 
 def describe_get_w3() -> None:
-    @pytest.mark.asyncio
     async def it_can_get_w3() -> None:
         alchemy_key = os.getenv("ALCHEMY_KEY_GOERLI")
         w3 = chains.get_w3(chains.Chain.GOERLI, alchemy_key=alchemy_key)
@@ -61,7 +60,6 @@ def describe_get_w3() -> None:
         assert block is not None
         assert block["number"] == latest_block["number"]
 
-    @pytest.mark.asyncio
     async def it_can_get_w3_from_env() -> None:
         w3 = chains.get_w3(chains.Chain.GOERLI)
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR set the pytest config in pytproject.toml to automatically use asyncio eventloop for async test. 



* **What is the current behavior?** (You can also link to an open issue here)
Currently, we have to add `@pytest.mark.asyncio` in tests. 


* **What is the new behavior (if this is a feature change)?**
We no longer need to add the verbose decorator. 

