### PR TITLE
use wallet history for invoice factoring tenure

### DIFF
--- a/huma_signals/adapters/request_network/adapter.py
+++ b/huma_signals/adapters/request_network/adapter.py
@@ -8,6 +8,7 @@ import pydantic
 import web3
 
 from huma_signals.adapters import models as adapter_models
+from huma_signals.adapters.ethereum_wallet import adapter as ethereum_wallet_adapter
 from huma_signals.adapters.request_network import models
 from huma_signals.commons import chains, tokens
 from huma_signals.settings import settings
@@ -216,13 +217,20 @@ class RequestNetworkInvoiceAdapter(adapter_models.SignalAdapterBase):
             ]
         )
 
+        # Fetch wallet tenure using ethereum_wallet adapter
+        payee_wallet = await ethereum_wallet_adapter.EthereumWalletAdapter().fetch(
+            invoice.payee
+        )
+        payer_wallet = await ethereum_wallet_adapter.EthereumWalletAdapter().fetch(
+            invoice.payer
+        )
         return models.RequestNetworkInvoiceSignals(
-            payer_tenure=payer_stats.get("earliest_txn_age_in_days", 0),
+            payer_tenure=payer_wallet.wallet_teneur_in_days,
             payer_recent=payer_stats.get("last_txn_age_in_days", 0),
             payer_count=payer_stats.get("total_txns", 0),
             payer_total_amount=payer_stats.get("total_amount", 0),
             payer_unique_payees=payer_stats.get("unique_payees", 0),
-            payee_tenure=payee_stats.get("earliest_txn_age_in_days", 0),
+            payee_tenure=payee_wallet.wallet_teneur_in_days,
             payee_recent=payee_stats.get("last_txn_age_in_days", 0),
             payee_count=payee_stats.get("total_txns", 0),
             payee_total_amount=payee_stats.get("total_amount", 0),

--- a/tests/adapters/request_network/test_adapter.py
+++ b/tests/adapters/request_network/test_adapter.py
@@ -69,7 +69,7 @@ def describe_adapter() -> None:
 
         @pytest.fixture
         def rn_invoice_api_url() -> str:
-            return "https://goerli.api.huma.finance/invoice"
+            return "https://dev.goerli.rnreader.huma.finance/invoice"
 
         @pytest.fixture
         def borrower_address() -> str:
@@ -77,7 +77,7 @@ def describe_adapter() -> None:
 
         @pytest.fixture
         def receivable_param() -> str:
-            return "0xdf135697d5b8b0ead72f8a80131c25c6fdb140bdc17d75652675fe801d9a5ff0"
+            return "0x0235"
 
         @pytest.fixture
         def payer_wallet_address() -> str:
@@ -104,15 +104,15 @@ def describe_adapter() -> None:
             assert signals.payer_recent == 999
             assert signals.payer_count == 0
             assert signals.payer_total_amount == decimal.Decimal("0")
-            assert signals.payee_tenure == 0
+            assert signals.payee_tenure > 7500
             assert signals.payee_recent == 999
             assert signals.payee_count == 0
             assert signals.payee_total_amount == decimal.Decimal("0")
             assert signals.mutual_count == 0
             assert signals.mutual_total_amount == decimal.Decimal("0")
-            assert signals.payee_match_borrower is True
-            assert signals.borrower_own_invoice is True
-            assert signals.payer_on_allowlist is False
+            assert signals.payee_match_borrower is False
+            assert signals.borrower_own_invoice is False
+            assert signals.payer_on_allowlist is True
 
         @mock.patch(
             "huma_signals.adapters.request_network.models.Invoice.from_request_id",
@@ -143,7 +143,7 @@ def describe_adapter() -> None:
             signals = await adapter.RequestNetworkInvoiceAdapter(
                 chain=chains.Chain.ETHEREUM,
                 request_network_subgraph_endpoint_url=mainnet_subgraph,
-                request_network_invoice_api_url="https://goerli.api.huma.finance/invoice",
+                request_network_invoice_api_url="https://dev.goerli.rnreader.huma.finance/invoice",
             ).fetch(
                 borrower_wallet_address=borrower_address,
                 receivable_param=receivable_param,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR updated the request network signal adapter to calculate payer_tenure and payee_tenure based on the account address' earlier transaction instead of limit to only invoice on RequestNetwork. 


* **What is the current behavior?** (You can also link to an open issue here)
Currently the two signals are only based on their earliest RN history, which can be too punishing for new users with solid history. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking change. But `request_network` adapter starts to take `ethereum_wallet` adapter as a dependency. 



* Tested with the following case: 
```
{
   "adapter_inputs":{
      "borrower_wallet_address":"0x251B787df47d79B933D217A13A6F7a13958F1219",
      "pool_address":"0x11672c0bBFF498c72BC2200f42461c0414855042",
      "receivable_address":"0xf17FF940864351631b1be3ac03702dEA085ba51c",
      "receivable_param":"0x0235"
   },
   "signal_names":[
      "request_network.payer_tenure",
      "request_network.payer_recent",
      "request_network.payer_count",
      "request_network.payee_tenure",
      "request_network.payee_recent",
      "request_network.payee_count",
      "request_network.mutual_count",
      "request_network.payee_match_borrower",
      "request_network.borrower_own_invoice",
      "request_network.days_until_due_date"
   ]
}
```