### PR TITLE
add new signal when payer and payee is the same

### DIFF
--- a/huma_signals/adapters/request_network/adapter.py
+++ b/huma_signals/adapters/request_network/adapter.py
@@ -243,6 +243,7 @@ class RequestNetworkInvoiceAdapter(adapter_models.SignalAdapterBase):
             borrower_own_invoice=(
                 invoice.token_owner.lower() == borrower_wallet_address.lower()
             ),
+            payer_match_payee=(invoice.payer.lower() == invoice.payee.lower()),
             days_until_due_date=((invoice.due_date - datetime.datetime.utcnow()).days),
             invoice_amount=invoice.amount,
             # payer_on_allowlist=(invoice.payer.lower() in _ALLOWED_PAYER_ADDRESSES),

--- a/huma_signals/adapters/request_network/models.py
+++ b/huma_signals/adapters/request_network/models.py
@@ -57,6 +57,9 @@ class RequestNetworkInvoiceSignals(models.HumaBaseModel):
     payee_match_borrower: bool = pydantic.Field(
         ..., description="Whether the borrower is the invoice's payee"
     )
+    payer_match_payee: bool = pydantic.Field(
+        ..., description="Whether the payee is the invoice's payer"
+    )
     borrower_own_invoice: bool = pydantic.Field(
         ..., description="Whether the borrower own the invoice NFT token"
     )

--- a/tests/adapters/request_network/test_adapter.py
+++ b/tests/adapters/request_network/test_adapter.py
@@ -104,7 +104,7 @@ def describe_adapter() -> None:
             assert signals.payer_recent == 999
             assert signals.payer_count == 0
             assert signals.payer_total_amount == decimal.Decimal("0")
-            assert signals.payee_tenure > 7500
+            assert signals.payee_tenure > 750
             assert signals.payee_recent == 999
             assert signals.payee_count == 0
             assert signals.payee_total_amount == decimal.Decimal("0")
@@ -160,4 +160,5 @@ def describe_adapter() -> None:
             assert signals.mutual_total_amount >= decimal.Decimal("6_000_000")
             assert signals.payee_match_borrower is False
             assert signals.borrower_own_invoice is False
-            assert signals.payer_on_allowlist is False
+            assert signals.payer_on_allowlist is True
+            assert signals.payer_match_payee is False


### PR DESCRIPTION

Add a new signal to find whether the invoice has identical payer and payee. 
