### PR TITLE
Remove explicit dependencies on ipfshttpclient and base58

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -264,21 +264,6 @@ files = [
 ]
 
 [[package]]
-name = "base58"
-version = "2.1.1"
-description = "Base58 and Base58Check implementation."
-category = "main"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2"},
-    {file = "base58-2.1.1.tar.gz", hash = "sha256:c5d0cb3f5b6e81e8e35da5754388ddcc6d0d14b6c6a132cb93d69ed580a7278c"},
-]
-
-[package.extras]
-tests = ["PyHamcrest (>=2.0.2)", "mypy", "pytest (>=4.6)", "pytest-benchmark", "pytest-cov", "pytest-flake8"]
-
-[[package]]
 name = "bitarray"
 version = "2.7.3"
 description = "efficient arrays of booleans -- C extension"
@@ -788,81 +773,81 @@ six = "*"
 
 [[package]]
 name = "ddtrace"
-version = "1.12.4"
+version = "1.12.6"
 description = "Datadog APM client library"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
-    {file = "ddtrace-1.12.4-cp27-cp27m-macosx_11_0_x86_64.whl", hash = "sha256:e60ea006dee202a73d14e879c4e6a2b8e48e1c72ac41892ebc7fd95fbbf4e5e3"},
-    {file = "ddtrace-1.12.4-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:4c9a6f39ee03a8d8bbbe7b10ae29f38373ab50cb87a092882a4550cfa9f24b0a"},
-    {file = "ddtrace-1.12.4-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9fa1ab49bbca27cbe1cbedea4d538ed7796c4e3077e650b3b30827fbd7c77cfa"},
-    {file = "ddtrace-1.12.4-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:730e32b62cc522224e04320e8441eecf18d332249a51f3d164e47c31b769527b"},
-    {file = "ddtrace-1.12.4-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:f612dea80b5d2265a893760efc6cadd4eca2f8b38cf799cdc7e395e78140babe"},
-    {file = "ddtrace-1.12.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:f588e38cf591f2504cd0310ce1196d3f930f46f6242ae7ba5660817535f64c7f"},
-    {file = "ddtrace-1.12.4-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:02926370cfff9a545329054e1a15fba68e37cd30a3cbec3e341da8f2d57a3eb9"},
-    {file = "ddtrace-1.12.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:658015c5b3b0b6da1d7ae86a405891df09c71e15c298c50db4bfa3cfcf68b843"},
-    {file = "ddtrace-1.12.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5db015841d8ebcb0f1d96ac8e59b0195d0ac54e8ba7c8f8095d2e55a0d5c634b"},
-    {file = "ddtrace-1.12.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:750e919252db22d6f1d4c5575362f2f922307cf59ba06d3f4c700981eed7423e"},
-    {file = "ddtrace-1.12.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4df2d9b7419466d124271b403178447589bc8decc016f75474f7cf49c14ce6b3"},
-    {file = "ddtrace-1.12.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:699b5763b2a19a26cdbdd74a356ac6b7b2ef87ee277ddfbd8f4f2de5fdfdaeb5"},
-    {file = "ddtrace-1.12.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:32d5fa326f1011b960e8f76f092759d127a17ea29a027ec63ef5113d1ca625c9"},
-    {file = "ddtrace-1.12.4-cp310-cp310-win32.whl", hash = "sha256:be61b4b0428a71de23a407925f5ab52fabbf86d2189fa62ac85555157dc4d3b3"},
-    {file = "ddtrace-1.12.4-cp310-cp310-win_amd64.whl", hash = "sha256:0d533ac33d927095b790ef286fadd1f9192176a9ebd0c2cf50968bb892fb10db"},
-    {file = "ddtrace-1.12.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:66f2742d1e43a05db13303bca79a9f2624583fa7ce89ca8b9f6bf5343f8cf765"},
-    {file = "ddtrace-1.12.4-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:b59f272e0acea625c7a1062239f98a6941efb1dbd9ecb0f3c26c7a3975c08800"},
-    {file = "ddtrace-1.12.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1579f3043718354af208d11b7df836d3c7fe8cfb10f03120a7f3192ec528f044"},
-    {file = "ddtrace-1.12.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f81acea86af2711fe2b4a1c25e35fb0b5e6ca5fe97c9becfa10e12e2ddee56e"},
-    {file = "ddtrace-1.12.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57e5562b849dbf311132a0af4cc6194bd0744e84015c069c80af2d2d4eb98db0"},
-    {file = "ddtrace-1.12.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0af357607db8bf192afe0be7ccc4b4594849156e439bb32a9008956434cf03f3"},
-    {file = "ddtrace-1.12.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4a260f5abb8ccebd5afec2ea3ce31d160e93677f63707eaa854cf8d02fdf01f4"},
-    {file = "ddtrace-1.12.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1dff5350494e00cac72e4d1c56ea6c0b03187c437622d2da09bf515e007fa111"},
-    {file = "ddtrace-1.12.4-cp311-cp311-win32.whl", hash = "sha256:01ef47f5eeeb2c4bce908fa81887d450b4b133085d49643b14c72ec57db8560f"},
-    {file = "ddtrace-1.12.4-cp311-cp311-win_amd64.whl", hash = "sha256:c12a605cceba414357483f2b018de9ce9fb73d486d06c35eba85f04983bba21d"},
-    {file = "ddtrace-1.12.4-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:c0f8a2b9814b072a9ce707e2ede38b48cb78a42c53fc6e469de44769ef690867"},
-    {file = "ddtrace-1.12.4-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:2098155790253d9811778d2bb6a4b0496dc5e391a3e45922790acb6721546629"},
-    {file = "ddtrace-1.12.4-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:a0d1bbad74949772e7150df7ecd3e35d9eabe37b39ca7f4179b602700066b2ef"},
-    {file = "ddtrace-1.12.4-cp35-cp35m-win32.whl", hash = "sha256:05dee2a920dc6bbf92e2ab6d87b27def9f5590d7db14defd42582e44eed9a6eb"},
-    {file = "ddtrace-1.12.4-cp35-cp35m-win_amd64.whl", hash = "sha256:4fc5fbdf56332af31715aed70ebd71815855cf86a5f0f1b75cddeadcddf8b600"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-macosx_11_0_x86_64.whl", hash = "sha256:b4ffab7ecb5b57fdb52293815cc921296582fdd5bdac9a5217ad9610141f722f"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:611e17bc223189f4ff09da4904854d140d3a0f2283ac2cf334e2bca100402d98"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:77a3d4afe8b7a60222ae2d89b72500782943b4097334896d4fdb801c3fce1e05"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fff37525304fcef9cf57053a051afd5f388e19d1a1e696a415fcb71048c66479"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9ab16ad95dc3c21be37017657f3e0ce6af17eaa28a379850892f9284d591765f"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:2846633454e1a2a5c4006f7e33a5a7fe9527211334d7e77870a033997666d320"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:5066cdc8c5383124f0f54945fc578778d19a9b5ba16780710998c5cacc85fc9b"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-win32.whl", hash = "sha256:608f9ad6e902a2673c82eff9ad8eae41c0bf9ae1bb710915722885f2bd33c838"},
-    {file = "ddtrace-1.12.4-cp36-cp36m-win_amd64.whl", hash = "sha256:a59987ed91a5a2cf533a16bbb2918b4a49d7bc1093360115b55221249f4493f9"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:52107ba429204c2e33539f3a57fa74c492b2a058f56133f18667c00d4604312f"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0241fcd8f14643799fd95866168f5754ea1da8060c61b125e6d9b83390b84f0"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1a298855b514582d98f3734577b677d7ea4c7359698ec94d194e3a27bffe5ded"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:039918fb3871411202142d17ee29028a469b070afa5c745fbf8b36d0f8d7a040"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec1197ff772a28cd0d6e9dcfbe12b0033aafc745a63e86e7d632982cbb59326"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:14b5ba0ab9b111c35c9198971990a24188f64823906b48e64e3e0a956f263004"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:992d8c9c5611cbd1e78acff5b1a65548b642898755a243fc613c6073234fd17f"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-win32.whl", hash = "sha256:c05fb18696520541e36d1bf5733f89b51e858361039228d3ba69ac8594590b4a"},
-    {file = "ddtrace-1.12.4-cp37-cp37m-win_amd64.whl", hash = "sha256:5f7b7c5f7a1adc8f95a55a26fc517aa631fd9a687c8560d2889d1abda235590f"},
-    {file = "ddtrace-1.12.4-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:785f3800da83579803f7e4a7a38955c64097c5926fb894ed6782f6b168ddb38c"},
-    {file = "ddtrace-1.12.4-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:9c9ef465762087d7c93b2b15179cf4f5675563430149dc407119b7b2d4b5476a"},
-    {file = "ddtrace-1.12.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a75d6376d8c8ff32b8debffe63c7566d2832d476f88785e2fd1935c42300e77c"},
-    {file = "ddtrace-1.12.4-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1761f831914a1a5bee34700f6f4b08dfda2b091ad694e0c58cdb731ed60d2b26"},
-    {file = "ddtrace-1.12.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19b8198edf8bae70791c1cb1b219b1f334273fade3808444e7c24facfc839ce6"},
-    {file = "ddtrace-1.12.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f754b63791dd8e9fbd807fdf21297a9e077d7af39ed4ba22cc67f026ac6cfb56"},
-    {file = "ddtrace-1.12.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:07cb09da88d398797cfdbfc6eb036fd0e193ab9e5d84b50dc6ba601c3de0ce59"},
-    {file = "ddtrace-1.12.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b085014e945a5696f21372639ebcf4b8df011deb0003d075971145e5d12ffa92"},
-    {file = "ddtrace-1.12.4-cp38-cp38-win32.whl", hash = "sha256:5c0ab5cc2fa0d0b1dee0e80ec1420cee7490d0b0f03b1459f77288b12e8984a5"},
-    {file = "ddtrace-1.12.4-cp38-cp38-win_amd64.whl", hash = "sha256:024a2abaa17637ea5b3684bcca8da55b944d3067e9e152ad8b4947f884811d31"},
-    {file = "ddtrace-1.12.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:1f5d768e415ade4116dd762954bcab07aa66b3d8538f662ccd33fb23c5349e94"},
-    {file = "ddtrace-1.12.4-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:86c6ecd2dfaf98b462daa79ac432487305354822b8ea633924a5aaabb9b0ab13"},
-    {file = "ddtrace-1.12.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4481c0dd841b9b932df142f6abae6bf1565a8b438cd461e6b0b2ab5e62ea9d18"},
-    {file = "ddtrace-1.12.4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c2fea9a55793fe089f526e9d0261b07f204863203abac5b5571e39e359c72ab"},
-    {file = "ddtrace-1.12.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:566e0096f8711d1721d0202cdab74050d2a49831a25da76a79ee09d4f6a993f5"},
-    {file = "ddtrace-1.12.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1cbb5af4ce6fadaa1e74c78299b2d8256f2e2d7e84ee7d0a57d146b1c3167916"},
-    {file = "ddtrace-1.12.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:672f007f980e38dae299288774a9ddf4707a7119ed526daa35366691bc831111"},
-    {file = "ddtrace-1.12.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6f7a846c1050933723344c3b09ee702ee11dd8d28466dc7301772406fbe3aa37"},
-    {file = "ddtrace-1.12.4-cp39-cp39-win32.whl", hash = "sha256:cbc6e3432e11632d2a363945a7c05bd7feb57e97e890dcab7a5ecfbb4cacac96"},
-    {file = "ddtrace-1.12.4-cp39-cp39-win_amd64.whl", hash = "sha256:a0789b4ee00ad283bd20824671e9273ed49d0c8c913d4dd1a218eafd9c8c6b57"},
-    {file = "ddtrace-1.12.4.tar.gz", hash = "sha256:f3b8938ba95a227b04112538071203a109bfc4974f13e59a2c0e936b093eaff8"},
+    {file = "ddtrace-1.12.6-cp27-cp27m-macosx_11_0_x86_64.whl", hash = "sha256:37972fbefbe376980e1fbecf3d731fe23098da5ddd56ecd757ef414e9e3f5e85"},
+    {file = "ddtrace-1.12.6-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:646b9fd47e52c8d92f6a7afce5ec8bdc40ca8349022d174c74addcce214ad140"},
+    {file = "ddtrace-1.12.6-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9efdb6458e24476cdf65344fcf206a82bac9d87e4a05a032f1a795615209ebf4"},
+    {file = "ddtrace-1.12.6-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:8dcb4ca405cd94741f771aed81929ccd54a791181c09fe27bd21fb652c825af3"},
+    {file = "ddtrace-1.12.6-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:3147301cebcda0e7b6497b0d2f363065a2ba28bcf627f865c3eec8fc68810885"},
+    {file = "ddtrace-1.12.6-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:60e2b158c4da099a574a7799a896375ade0a2ab63df87f96d68102c48f7cc8b5"},
+    {file = "ddtrace-1.12.6-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:e4acc19be7443f20185d4a453e65cc36519821b06a9a137c7b2422f4b38f08fd"},
+    {file = "ddtrace-1.12.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e429855a3926c6e028af2f2a19febdbc9428c9015e6dc2b305f7ae087aea7f9"},
+    {file = "ddtrace-1.12.6-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92d0a5056f48e1664709af89e95f1ff66d14df97d2b70f7cb1a685618d59a3e8"},
+    {file = "ddtrace-1.12.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:135ffa0415edee6e31c8e640b3256ff20453b8a603e409d84e961de1b6c14a6b"},
+    {file = "ddtrace-1.12.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c4a25b566a88635382ee880de34cf3567ede0b29db57a2cdfb4fccfdde8c8558"},
+    {file = "ddtrace-1.12.6-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:d32926e89c008b01caee98de74890323f546022c3ed63268c169c8c255a3c24e"},
+    {file = "ddtrace-1.12.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9df5eea75c4a26f32f0764cbbf2856d55f4113c96649f836e9cb62613aebfb73"},
+    {file = "ddtrace-1.12.6-cp310-cp310-win32.whl", hash = "sha256:4e991327b02890f040a98c40a2e32e2b822940857890a75bac8e860b2a311606"},
+    {file = "ddtrace-1.12.6-cp310-cp310-win_amd64.whl", hash = "sha256:b9190ad753b7f24b32c4e0e71f88b101e39269a611231f53d23df560df3a8a55"},
+    {file = "ddtrace-1.12.6-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:56aa090f48fa4ce32bbf296fc457dfaf49e0e9dda75e02f68699de7f37976a32"},
+    {file = "ddtrace-1.12.6-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:309cce75bc522841e3537e0251be35466122f2373e67e9884a6e43e11c192d66"},
+    {file = "ddtrace-1.12.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7100079d0d2787fa0a85d1ae81c67971f95e8a740a105e0e4e6e24c365c9495d"},
+    {file = "ddtrace-1.12.6-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da9f5b51509bfaf88394797e9c787cdfb65184ae2591ce7eb378f29864f6e4ca"},
+    {file = "ddtrace-1.12.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09bbc428af6455f1c3bc8b9a3243d5053f4504c4538c04a289f956801b6266fa"},
+    {file = "ddtrace-1.12.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8db3a722d19366806e701369b0a4ee1a978c827eb77b4d60eb14237b1d565ade"},
+    {file = "ddtrace-1.12.6-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6a83e8974b591294990ad9dad53347b0a9f36eb11dbcb778d63593323793d414"},
+    {file = "ddtrace-1.12.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a1a3a176ed0aaf1d95c34aed2d34f0e90b58640b19e5da4a841763d3856a358d"},
+    {file = "ddtrace-1.12.6-cp311-cp311-win32.whl", hash = "sha256:94424393bffc27e777cf2110746c51694f19e7fa45a674764585040c7df11c5b"},
+    {file = "ddtrace-1.12.6-cp311-cp311-win_amd64.whl", hash = "sha256:f8cee34ee56ccbf14bd430c20ea9b7d9bdcd1b32bdd3b9c0fdd86e3b4aeeb5c9"},
+    {file = "ddtrace-1.12.6-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:93ab39a6f177c04aa75974c31b56b39a36737e65ced94b671bea5d678a1cb46e"},
+    {file = "ddtrace-1.12.6-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:376be5563b028d00ccdc1e78e4703b239a3a1027672e964939815ac321fb4132"},
+    {file = "ddtrace-1.12.6-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:7f580a6f10a2f9469e55bd6353654f3613a981ea0a84c9b5a25999ea12483641"},
+    {file = "ddtrace-1.12.6-cp35-cp35m-win32.whl", hash = "sha256:b35dbf1881c8af745f6782fa5f94ddf0b0f991bc93d11550e1b74198142a26ac"},
+    {file = "ddtrace-1.12.6-cp35-cp35m-win_amd64.whl", hash = "sha256:ef42ab7d235bc315f5004f6813ada622e0cfc62679b68dc4fd6c892645c0b60c"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-macosx_11_0_x86_64.whl", hash = "sha256:da925b5b440de9eed74b6632f81f8e77312649dcf551413440134c8a656c9c30"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87787322bab618369ac68dd87f9dadaf6093e5628a767f63c96e0e3f9befb6cc"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5406192413680342b7b9429f0a7da447df93fce5ef34def79f4e64f7e2cc13e7"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04c66180b543c1626c3c3eab40f9dbf1d724644d301de3b3f4a889f71f01b1dc"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:ba1635a6f37623c64e2aa715e78a85e9b5846f1cf205bdde3e582078aaae1f66"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:3d95e92fbcd8cafbe410eed9e7b3d5c4494e0d5f209423968ad09a831fd8b6af"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:f744dd743db1f9ef319c4e2ba06330703c5062c721b9ab9c6226e6f5956602b4"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-win32.whl", hash = "sha256:5570c0738384c04a399c1d3a7803adcaec902f641653ce15f13012210e5d635f"},
+    {file = "ddtrace-1.12.6-cp36-cp36m-win_amd64.whl", hash = "sha256:1b9faba6bdf1664dc4894977ffe9c129efa2965f796886a15b850cc71c6cfd1c"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:b7c9192d3aed430dff903ddf0f005636c3cd91b6e7d1656be911c573c379913d"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:349ca38e85ac889be22046ddd1b5d82b01d7f3079d85a1ba6830fca53b7e4c81"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb22815c55776bca05d44ac35238f758f3d8cc8c623db5eb2e5637521a49faa3"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:515a33bdfa0ee528fdbd8e3b2f518702142af472f7065244b9222b06a08721fb"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:4c6e09bbae00c0b1b5a84ae3e9385b8e858d00f67c422db8c086e7a97f94c94d"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f72daeba3f1839b78364861abde86b1a98d142f572ec91680783b0d1f0e1121a"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:055ae20648ca52dc32a5372eb57401b9506b7a8a45584d3d4331e513a343a38e"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-win32.whl", hash = "sha256:379df790ca0edfa4c42e20eacb1f2ab4c2e7a19bb64b350a37b865c445a700b8"},
+    {file = "ddtrace-1.12.6-cp37-cp37m-win_amd64.whl", hash = "sha256:f52a878484d8b594b59bc124644e33767613cd4a02ecbcdd0abed2454c723c66"},
+    {file = "ddtrace-1.12.6-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1dfe54435d4b9214e24fff83a62f41e5b9447485132a99af490c859ed30884bc"},
+    {file = "ddtrace-1.12.6-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:9fe2322a4f40cea827ddcfcb50030e9ca73f9403a944e38f8969e7f8a4773642"},
+    {file = "ddtrace-1.12.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc8f697eccafe879953c02f8ccdb40b30dde1c38d2053961b6ecdd3020a2b65"},
+    {file = "ddtrace-1.12.6-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6a6425b0bafd1f4d41a3526878612c4f9d7c779da5fff2b907286a63b3692da"},
+    {file = "ddtrace-1.12.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9077b0e5de4855c2a82d34e0b4db00d4decc47dfe9dd635160271c27fe3231bb"},
+    {file = "ddtrace-1.12.6-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ea22ad6d4d980e62aed28e125ea046a56e9742bb3d8bd0950bd2ac1a9fe7e098"},
+    {file = "ddtrace-1.12.6-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5047d10918b6ea12ff745354d4bf28fb4e5a22b6fede9710df3e7eb85f88176a"},
+    {file = "ddtrace-1.12.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8f0af31130552a9ea3ff78fdd30b115f62bab17e562e9239828424edc2bd6340"},
+    {file = "ddtrace-1.12.6-cp38-cp38-win32.whl", hash = "sha256:0d3cb0682efd1b8427a12ee6e1c815ac700736c51514f1292927809a08b864e1"},
+    {file = "ddtrace-1.12.6-cp38-cp38-win_amd64.whl", hash = "sha256:a7a410974193b73271459a39937e18d3698069e5c26658370fc574639e77b90f"},
+    {file = "ddtrace-1.12.6-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:07460701fccb8f97ec93ea1887fb6c0b7099983e8780169f20636d7206d937f1"},
+    {file = "ddtrace-1.12.6-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:cfff288ecb12b8b1497d6cbaab8a5bb3a63add1e61bbe76d8b1bb6eb3d8e9bbd"},
+    {file = "ddtrace-1.12.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5101f36348f01db30d887df123669445717ba2bc7897f830a45872959303f772"},
+    {file = "ddtrace-1.12.6-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fc4e0ff1560c10555536ffdc34cbb74312f6f47d5d0d66d273806be913ae98a"},
+    {file = "ddtrace-1.12.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:542fc1ec7f7f0f3342823dab6a7c4fd5a8f221d08800f3519d829c584f033f69"},
+    {file = "ddtrace-1.12.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a6a0ab05de26a7fb34b70e97b5438942ca0ad9fbcf1b1ca4c89c699709e6c69a"},
+    {file = "ddtrace-1.12.6-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:aa7c67dae08b5502b58f87eb899b692ad912dd398323f3a801035b479bd83b50"},
+    {file = "ddtrace-1.12.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d8cdfeb08302e6938b84eda6d7ca791bbbe4073e60f7f1cdc2a23a2f1e1f9bcd"},
+    {file = "ddtrace-1.12.6-cp39-cp39-win32.whl", hash = "sha256:cee982a59ef61102e70cf03e13c23c8234c386c433d6a232c5133a28e7394d01"},
+    {file = "ddtrace-1.12.6-cp39-cp39-win_amd64.whl", hash = "sha256:453e0a47121d8fb74af17a00e91a9321e186a5ac5bf06094d54a6e6239fffdd4"},
+    {file = "ddtrace-1.12.6.tar.gz", hash = "sha256:08eebaa5c2b41b21c22ddd4c1934a0e02d198b7ddc3314e8eb653b78a6916edb"},
 ]
 
 [package.dependencies]
@@ -1481,22 +1466,6 @@ files = [
 ]
 
 [[package]]
-name = "ipfshttpclient"
-version = "0.7.0"
-description = "Python IPFS HTTP CLIENT library"
-category = "main"
-optional = false
-python-versions = ">=3.5.4,!=3.6.0,!=3.6.1,!=3.7.0,!=3.7.1"
-files = [
-    {file = "ipfshttpclient-0.7.0-py3-none-any.whl", hash = "sha256:161c348e91cdc194c06c8725446a51a2d758ff2cc5ea97ec98f49e2af2465405"},
-    {file = "ipfshttpclient-0.7.0.tar.gz", hash = "sha256:feb1033c14c3ac87ee81264176c5beefeaf386385804427160466117ccc43693"},
-]
-
-[package.dependencies]
-multiaddr = ">=0.0.7"
-requests = ">=2.11"
-
-[[package]]
 name = "ipython"
 version = "8.13.2"
 description = "IPython: Productive Interactive Computing"
@@ -1728,24 +1697,6 @@ files = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.0.9"
-description = "Python implementation of jbenet's multiaddr"
-category = "main"
-optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-files = [
-    {file = "multiaddr-0.0.9-py2.py3-none-any.whl", hash = "sha256:5c0f862cbcf19aada2a899f80ef896ddb2e85614e0c8f04dd287c06c69dac95b"},
-    {file = "multiaddr-0.0.9.tar.gz", hash = "sha256:30b2695189edc3d5b90f1c303abb8f02d963a3a4edf2e7178b975eb417ab0ecf"},
-]
-
-[package.dependencies]
-base58 = "*"
-netaddr = "*"
-six = "*"
-varint = "*"
-
-[[package]]
 name = "multidict"
 version = "6.0.4"
 description = "multidict implementation"
@@ -1890,18 +1841,6 @@ python-versions = ">=3.5"
 files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
-name = "netaddr"
-version = "0.8.0"
-description = "A network address manipulation library for Python"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "netaddr-0.8.0-py2.py3-none-any.whl", hash = "sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac"},
-    {file = "netaddr-0.8.0.tar.gz", hash = "sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243"},
 ]
 
 [[package]]
@@ -2253,25 +2192,25 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "4.22.4"
+version = "4.23.0"
 description = ""
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "protobuf-4.22.4-cp310-abi3-win32.whl", hash = "sha256:a4e661247896c2ffea4b894bca2d8657e752bedb8f3c66d7befa2557291be1e8"},
-    {file = "protobuf-4.22.4-cp310-abi3-win_amd64.whl", hash = "sha256:7b42086d6027be2730151b49f27b2f5be40f3b036adf7b8da5917f4567f268c3"},
-    {file = "protobuf-4.22.4-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:4bfb28d48628deacdb66a95aaa7b6640f3dc82b4edd34db444c7a3cdd90b01fb"},
-    {file = "protobuf-4.22.4-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:e98e26328d7c668541d1052b02de4205b1094ef6b2ce57167440d3e39876db48"},
-    {file = "protobuf-4.22.4-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:8fd329e5dd7b6c4b878cab4b85bb6cec880e2adaf4e8aa2c75944dcbb05e1ff1"},
-    {file = "protobuf-4.22.4-cp37-cp37m-win32.whl", hash = "sha256:b7728b5da9eee15c0aa3baaee79e94fa877ddcf7e3d2f34b1eab586cd26eea89"},
-    {file = "protobuf-4.22.4-cp37-cp37m-win_amd64.whl", hash = "sha256:f4a711588c3a79b6f9c44af4d7f4a2ae868e27063654683932ab6462f90e9656"},
-    {file = "protobuf-4.22.4-cp38-cp38-win32.whl", hash = "sha256:11b28b4e779d7f275e3ea0efa3938f4d4e8ed3ca818f9fec3b193f8e9ada99fd"},
-    {file = "protobuf-4.22.4-cp38-cp38-win_amd64.whl", hash = "sha256:144d5b46df5e44f914f715accaadf88d617242ba5a40cacef4e8de7effa79954"},
-    {file = "protobuf-4.22.4-cp39-cp39-win32.whl", hash = "sha256:5128b4d5efcaef92189e076077ae389700606ff81d2126b8361dc01f3e026197"},
-    {file = "protobuf-4.22.4-cp39-cp39-win_amd64.whl", hash = "sha256:9537ae27d43318acf8ce27d0359fe28e6ebe4179c3350bc055bb60ff4dc4fcd3"},
-    {file = "protobuf-4.22.4-py3-none-any.whl", hash = "sha256:3b21074b7fb748d8e123acaef9fa63a84fdc1436dc71199d2317b139f77dd6f4"},
-    {file = "protobuf-4.22.4.tar.gz", hash = "sha256:21fbaef7f012232eb8d6cb8ba334e931fc6ff8570f5aaedc77d5b22a439aa909"},
+    {file = "protobuf-4.23.0-cp310-abi3-win32.whl", hash = "sha256:6c16657d6717a0c62d5d740cb354fbad1b0d8cb811669e06fc1caa0ff4799ddd"},
+    {file = "protobuf-4.23.0-cp310-abi3-win_amd64.whl", hash = "sha256:baca40d067dddd62141a129f244703160d278648b569e90bb0e3753067644711"},
+    {file = "protobuf-4.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:2b94bd6df92d71bd1234a2ffe7ce96ddf6d10cf637a18d6b55ad0a89fbb7fc21"},
+    {file = "protobuf-4.23.0-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:9f5a0fbfcdcc364f3986f9ed9f8bb1328fb84114fd790423ff3d7fdb0f85c2d1"},
+    {file = "protobuf-4.23.0-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:ebde3a023b8e11bfa6c890ef34cd6a8b47d586f26135e86c21344fe433daf2e2"},
+    {file = "protobuf-4.23.0-cp37-cp37m-win32.whl", hash = "sha256:7cb5b9a05ce52c6a782bb97de52679bd3438ff2b7460eff5da348db65650f227"},
+    {file = "protobuf-4.23.0-cp37-cp37m-win_amd64.whl", hash = "sha256:6fe180b56e1169d72ecc4acbd39186339aed20af5384531b8e8979b02bbee159"},
+    {file = "protobuf-4.23.0-cp38-cp38-win32.whl", hash = "sha256:d5a35ff54e3f62e8fc7be02bb0d2fbc212bba1a5a9cc2748090690093996f07b"},
+    {file = "protobuf-4.23.0-cp38-cp38-win_amd64.whl", hash = "sha256:e62fb869762b4ba18666370e2f8a18f17f8ab92dd4467295c6d38be6f8fef60b"},
+    {file = "protobuf-4.23.0-cp39-cp39-win32.whl", hash = "sha256:03eee35b60317112a72d19c54d0bff7bc58ff12fea4cd7b018232bd99758ffdf"},
+    {file = "protobuf-4.23.0-cp39-cp39-win_amd64.whl", hash = "sha256:36f5370a930cb77c8ad2f4135590c672d0d2c72d4a707c7d0058dce4b4b4a598"},
+    {file = "protobuf-4.23.0-py3-none-any.whl", hash = "sha256:9744e934ea5855d12191040ea198eaf704ac78665d365a89d9572e3b627c2688"},
+    {file = "protobuf-4.23.0.tar.gz", hash = "sha256:5f1eba1da2a2f3f7df469fccddef3cc060b8a16cfe3cc65961ad36b4dbcf59c5"},
 ]
 
 [[package]]
@@ -3162,17 +3101,6 @@ h11 = ">=0.8"
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [[package]]
-name = "varint"
-version = "1.0.2"
-description = "Simple python varint implementation"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "varint-1.0.2.tar.gz", hash = "sha256:a6ecc02377ac5ee9d65a6a8ad45c9ff1dac8ccee19400a5950fb51d594214ca5"},
-]
-
-[[package]]
 name = "vcrpy"
 version = "4.2.1"
 description = "Automatically mock your HTTP interactions to simplify and speed up testing"
@@ -3541,4 +3469,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "f39a8532ac32fce687c8afb9ca923588d12e3d50fd4e7ab2da6439f978ca7ec9"
+content-hash = "4685fc8423a9b86db8c5052149f8b000d50b2c66d3cdeec4b7c4265867bc0063"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3065,21 +3065,20 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "1.26.15"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
+    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -3469,4 +3468,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "4685fc8423a9b86db8c5052149f8b000d50b2c66d3cdeec4b7c4265867bc0063"
+content-hash = "75003034460459ad3bfd868ab3308f21c3d2a2f41be578c96abaa8b211b70285"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ aiofiles = "^22.1.0"
 orjson = "^3.8.5"
 ddtrace = {extras = ["opentracing"], version = "^1.7.5"}
 datadog = "^0.44.0"
+urllib3 = "^1.26"
 
 [tool.poetry.group.dev.dependencies]
 pytest-describe = "^2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ pandas = "^1.5.2"
 python-dotenv = "^0.21.0"
 web3 = "^6.1.0"
 httpx = "^0.24.0"
-base58 = "^2.1.1"
-ipfshttpclient = "^0.7.0"
 aiofiles = "^22.1.0"
 orjson = "^3.8.5"
 ddtrace = {extras = ["opentracing"], version = "^1.7.5"}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
They were required as part of the switch to web3.py 6.0 pre-release, but not anymore.

Also adding a py.typed file to let mypy know to use the type annotations in this package for type checking.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: